### PR TITLE
Convert all tabs to spaces. 

### DIFF
--- a/gofetchnews/gofetchnews.go
+++ b/gofetchnews/gofetchnews.go
@@ -1,85 +1,85 @@
 package gofetchnews
 
 import (
-	"fmt"
-	"github.com/josephpd3/gofetchnews/refs"
-	"log"
-	"net/http"
-	"net/url"
-	"time"
+    "fmt"
+    "github.com/josephpd3/gofetchnews/refs"
+    "log"
+    "net/http"
+    "net/url"
+    "time"
 
-	"github.com/PuerkitoBio/goquery"
-	"github.com/josephpd3/gofetchnews/publications"
+    "github.com/PuerkitoBio/goquery"
+    "github.com/josephpd3/gofetchnews/publications"
 )
 
 // FetchReferences takes a variable number of URLs for news articles and
 // attempts to retrieve linked references from within them
 func FetchReferences(articleURLs ...string) {
-	httpClient := http.Client{
-		Timeout: 30 * time.Second,
-	}
+    httpClient := http.Client{
+        Timeout: 30 * time.Second,
+    }
 
-	// Collect all channels in a list to merge after parsing all URLs for processing
-	var allReferences []<-chan refs.Reference
+    // Collect all channels in a list to merge after parsing all URLs for processing
+    var allReferences []<-chan refs.Reference
 
-	for _, articleURL := range articleURLs {
-		// Fetch a goquery.Document of the article HTML
-		article := fetchArticle(httpClient, articleURL)
+    for _, articleURL := range articleURLs {
+        // Fetch a goquery.Document of the article HTML
+        article := fetchArticle(httpClient, articleURL)
 
-		// Parse the URL to retrieve the hostname and map to a known publication
-		parsedURL, err := url.Parse(articleURL)
-		if err != nil {
-			log.Fatal(err)
-		}
+        // Parse the URL to retrieve the hostname and map to a known publication
+        parsedURL, err := url.Parse(articleURL)
+        if err != nil {
+            log.Fatal(err)
+        }
 
-		pub, ok := publications.HostPublicationMap[parsedURL.Hostname()]
-		if !ok {
-			log.Fatal("Publication not recognized!")
-		}
+        pub, ok := publications.HostPublicationMap[parsedURL.Hostname()]
+        if !ok {
+            log.Fatal("Publication not recognized!")
+        }
 
-		// Depending on the publication, fetch references in that particular site's article format
-		switch pub {
-		case publications.WashingtonPost:
-			references, err := publications.FetchWaPoReferences(article)
-			if err != nil {
-				log.Fatal(err)
-			} else {
-				allReferences = append(allReferences, references)
-			}
-		case publications.NewYorkTimes:
-			references, err := publications.FetchNYTReferences(article)
-			if err != nil {
-				log.Fatal(err)
-			} else {
-				allReferences = append(allReferences, references)
-			}
-		default:
-			log.Fatal("Parser not written for publication!")
-		}
+        // Depending on the publication, fetch references in that particular site's article format
+        switch pub {
+        case publications.WashingtonPost:
+            references, err := publications.FetchWaPoReferences(article)
+            if err != nil {
+                log.Fatal(err)
+            } else {
+                allReferences = append(allReferences, references)
+            }
+        case publications.NewYorkTimes:
+            references, err := publications.FetchNYTReferences(article)
+            if err != nil {
+                log.Fatal(err)
+            } else {
+                allReferences = append(allReferences, references)
+            }
+        default:
+            log.Fatal("Parser not written for publication!")
+        }
 
-	}
+    }
 
-	printReferences(refs.MergeOutboundReferenceChannels(allReferences...))
+    printReferences(refs.MergeOutboundReferenceChannels(allReferences...))
 }
 
 // Internal helper for fetching a goquery.Document given an http.Client and a URL
 func fetchArticle(httpClient http.Client, url string) *goquery.Document {
-	response, err := httpClient.Get(url)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer response.Body.Close()
+    response, err := httpClient.Get(url)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer response.Body.Close()
 
-	document, err := goquery.NewDocumentFromResponse(response)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return document
+    document, err := goquery.NewDocumentFromResponse(response)
+    if err != nil {
+        log.Fatal(err)
+    }
+    return document
 }
 
 // Internal helper for printing references as a test
 func printReferences(ch <-chan refs.Reference) {
-	for ref := range ch {
-		fmt.Println(ref)
-	}
+    for ref := range ch {
+        fmt.Println(ref)
+    }
 }

--- a/main.go
+++ b/main.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"github.com/josephpd3/gofetchnews/gofetchnews"
+    "github.com/josephpd3/gofetchnews/gofetchnews"
 )
 
 var testPages = []string{
-	"https://www.washingtonpost.com/world/national-security/trump-administration-to-circumvent-court-limits-on-detention-of-child-migrants/2018/09/06/181d376c-b1bd-11e8-a810-4d6b627c3d5d_story.html",
-	"https://www.nytimes.com/2018/09/05/business/media/new-york-times-trump-anonymous.html",
+    "https://www.washingtonpost.com/world/national-security/trump-administration-to-circumvent-court-limits-on-detention-of-child-migrants/2018/09/06/181d376c-b1bd-11e8-a810-4d6b627c3d5d_story.html",
+    "https://www.nytimes.com/2018/09/05/business/media/new-york-times-trump-anonymous.html",
 }
 
 func main() {
-	gofetchnews.FetchReferences(testPages...)
+    gofetchnews.FetchReferences(testPages...)
 }

--- a/publications/ny_times.go
+++ b/publications/ny_times.go
@@ -6,47 +6,47 @@ This file is specific to The New York Times
 package publications
 
 import (
-	"errors"
+    "errors"
 
-	"github.com/PuerkitoBio/goquery"
-	"github.com/josephpd3/gofetchnews/refs"
+    "github.com/PuerkitoBio/goquery"
+    "github.com/josephpd3/gofetchnews/refs"
 )
 
 // FetchNYTReferences fetches all references in a New York Times article
 // If there are issues parsing the article's body, an error will be returned
 func FetchNYTReferences(article *goquery.Document) (<-chan refs.Reference, error) {
-	ch := make(chan refs.Reference)
+    ch := make(chan refs.Reference)
 
-	articleBody := article.Find("article#story").First()
-	// Check to see if we have a match on our article body selector
-	if len(articleBody.Nodes) != 0 {
-		go parseNYTArticleBody(articleBody, ch)
-		return ch, nil
-	}
+    articleBody := article.Find("article#story").First()
+    // Check to see if we have a match on our article body selector
+    if len(articleBody.Nodes) != 0 {
+        go parseNYTArticleBody(articleBody, ch)
+        return ch, nil
+    }
 
-	return nil, errors.New("could not parse article")
+    return nil, errors.New("could not parse article")
 }
 
 // Internal helper to parse paragraphs in article and delegate to parseNYTParagraph
 func parseNYTArticleBody(articleBody *goquery.Selection, ch chan<- refs.Reference) {
-	articleBody.Find("p").Each(refs.CallWithRefChannel(refs.GQChannelAndCallback{
-		Channel:  ch,
-		Callback: parseNYTParagraph,
-	}))
-	close(ch)
+    articleBody.Find("p").Each(refs.CallWithRefChannel(refs.GQChannelAndCallback{
+        Channel:  ch,
+        Callback: parseNYTParagraph,
+    }))
+    close(ch)
 }
 
 // Internal helper to parse links out of paragraphs to construct References to send back via channel
 func parseNYTParagraph(index int, element *goquery.Selection, ch chan<- refs.Reference) {
-	paragraphText := element.Text()
-	element.Find("a").Each(func(idx int, e *goquery.Selection) {
-		href, exists := e.Attr("href")
-		if exists {
-			ch <- refs.Reference{
-				Href:    href,
-				Text:    e.Text(),
-				Context: paragraphText,
-			}
-		}
-	})
+    paragraphText := element.Text()
+    element.Find("a").Each(func(idx int, e *goquery.Selection) {
+        href, exists := e.Attr("href")
+        if exists {
+            ch <- refs.Reference{
+                Href:    href,
+                Text:    e.Text(),
+                Context: paragraphText,
+            }
+        }
+    })
 }

--- a/publications/publications.go
+++ b/publications/publications.go
@@ -4,12 +4,12 @@ type publication int
 
 // These constants represent various publications
 const (
-	WashingtonPost publication = iota + 1
-	NewYorkTimes
+    WashingtonPost publication = iota + 1
+    NewYorkTimes
 )
 
 // HostPublicationMap maps hostnames to their respective publications
 var HostPublicationMap = map[string]publication{
-	"www.nytimes.com": NewYorkTimes,
-	"www.washingtonpost.com": WashingtonPost,
+    "www.nytimes.com": NewYorkTimes,
+    "www.washingtonpost.com": WashingtonPost,
 }

--- a/publications/wapo.go
+++ b/publications/wapo.go
@@ -6,47 +6,47 @@ This file is specific to The Washington Post
 package publications
 
 import (
-	"errors"
+    "errors"
 
-	"github.com/PuerkitoBio/goquery"
-	"github.com/josephpd3/gofetchnews/refs"
+    "github.com/PuerkitoBio/goquery"
+    "github.com/josephpd3/gofetchnews/refs"
 )
 
 // FetchWaPoReferences fetches all references in a Washington Post article
 // If there are issues parsing the article's body, an error will be returned
 func FetchWaPoReferences(article *goquery.Document) (<-chan refs.Reference, error) {
-	ch := make(chan refs.Reference)
+    ch := make(chan refs.Reference)
 
-	articleBody := article.Find("article[itemprop=\"articleBody\"]").First()
-	// Check to see if we have a match on our article body selector
-	if len(articleBody.Nodes) != 0 {
-		go parseWaPoArticleBody(articleBody, ch)
-		return ch, nil
-	}
+    articleBody := article.Find("article[itemprop=\"articleBody\"]").First()
+    // Check to see if we have a match on our article body selector
+    if len(articleBody.Nodes) != 0 {
+        go parseWaPoArticleBody(articleBody, ch)
+        return ch, nil
+    }
 
-	return nil, errors.New("could not parse article")
+    return nil, errors.New("could not parse article")
 }
 
 // Internal helper to parse paragraphs in article and delegate to parseWaPoParagraph
 func parseWaPoArticleBody(articleBody *goquery.Selection, ch chan<- refs.Reference) {
-	articleBody.Find("p").Each(refs.CallWithRefChannel(refs.GQChannelAndCallback{
-		Channel:  ch,
-		Callback: parseWaPoParagraph,
-	}))
-	close(ch)
+    articleBody.Find("p").Each(refs.CallWithRefChannel(refs.GQChannelAndCallback{
+        Channel:  ch,
+        Callback: parseWaPoParagraph,
+    }))
+    close(ch)
 }
 
 // Internal helper to parse links out of paragraphs to construct References to send back via channel
 func parseWaPoParagraph(index int, element *goquery.Selection, ch chan<- refs.Reference) {
-	paragraphText := element.Text()
-	element.Find("a").Each(func(idx int, e *goquery.Selection) {
-		href, exists := e.Attr("href")
-		if exists {
-			ch <- refs.Reference{
-				Href:    href,
-				Text:    e.Text(),
-				Context: paragraphText,
-			}
-		}
-	})
+    paragraphText := element.Text()
+    element.Find("a").Each(func(idx int, e *goquery.Selection) {
+        href, exists := e.Attr("href")
+        if exists {
+            ch <- refs.Reference{
+                Href:    href,
+                Text:    e.Text(),
+                Context: paragraphText,
+            }
+        }
+    })
 }

--- a/refs/refs.go
+++ b/refs/refs.go
@@ -1,34 +1,34 @@
 package refs
 
 import (
-	"fmt"
-	"sync"
+    "fmt"
+    "sync"
 
-	"github.com/PuerkitoBio/goquery"
+    "github.com/PuerkitoBio/goquery"
 )
 
 // Reference refers to a link within an article and its context (containing paragraph or sentence)
 type Reference struct {
-	Href    string
-	Text    string
-	Context string
+    Href    string
+    Text    string
+    Context string
 }
 
 func (r Reference) String() string {
-	return fmt.Sprintf("Reference{ Href: '%v', Text: '%v', Context: '%v'}", r.Href, r.Text, r.Context)
+    return fmt.Sprintf("Reference{ Href: '%v', Text: '%v', Context: '%v'}", r.Href, r.Text, r.Context)
 }
 
 // GQChannelAndCallback wraps an output channel and a callback for use in GoQuery selections
 type GQChannelAndCallback struct {
-	Channel  chan<- Reference
-	Callback func(int, *goquery.Selection, chan<- Reference)
+    Channel  chan<- Reference
+    Callback func(int, *goquery.Selection, chan<- Reference)
 }
 
 // CallWithRefChannel creates a function that injects an input channel implicitly via a closure
 func CallWithRefChannel(channelAndCallback GQChannelAndCallback) func(int, *goquery.Selection) {
-	return func(index int, element *goquery.Selection) {
-		channelAndCallback.Callback(index, element, channelAndCallback.Channel)
-	}
+    return func(index int, element *goquery.Selection) {
+        channelAndCallback.Callback(index, element, channelAndCallback.Channel)
+    }
 }
 
 // MergeOutboundReferenceChannels merges output channels of References
@@ -38,20 +38,20 @@ func CallWithRefChannel(channelAndCallback GQChannelAndCallback) func(int, *goqu
 // https://medium.com/justforfunc/two-ways-of-merging-n-channels-in-go-43c0b57cd1de
 // - - -
 func MergeOutboundReferenceChannels(cs ...<-chan Reference) <-chan Reference {
-	out := make(chan Reference)
-	var wg sync.WaitGroup
-	wg.Add(len(cs))
-	for _, c := range cs {
-		go func(c <-chan Reference) {
-			for v := range c {
-				out <- v
-			}
-			wg.Done()
-		}(c)
-	}
-	go func() {
-		wg.Wait()
-		close(out)
-	}()
-	return out
+    out := make(chan Reference)
+    var wg sync.WaitGroup
+    wg.Add(len(cs))
+    for _, c := range cs {
+        go func(c <-chan Reference) {
+            for v := range c {
+                out <- v
+            }
+            wg.Done()
+        }(c)
+    }
+    go func() {
+        wg.Wait()
+        close(out)
+    }()
+    return out
 }


### PR DESCRIPTION
Since tabs were the vscode default for Go, I though it was the standard. I was wrong.